### PR TITLE
Switch to using a Vagrant box from "bento" project since "boxcutter" …

### DIFF
--- a/vm.yml
+++ b/vm.yml
@@ -34,7 +34,7 @@ VM:
   # Images:
   # -> box-cutter/ubuntu1604
   #
-  image: 'box-cutter/ubuntu1604'
+  image: 'bento/ubuntu-16.04'
 
   # Enable GUI mode (show screen of VM)
   gui: false


### PR DESCRIPTION
…is no longer providing pre-built images.

Reference: https://github.com/boxcutter/ubuntu/issues/133#issuecomment-339929663