### PR TITLE
Workaround for VirtualBox 5.x bug for disconnected NAT interface

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -205,6 +205,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         v.customize ["modifyvm", :id, "--natdnsproxy1",        "on"]
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        # Workaround for https://github.com/hashicorp/vagrant/issues/7648
+        # See also: https://github.com/laravel/homestead/issues/383
+        v.customize ['modifyvm', :id, '--cableconnected1',     'on']
 
         # GFX settings
         v.customize ["modifyvm", :id, "--vram",               configuration['VM']['vram']]


### PR DESCRIPTION
Issue bringing up the Vagrant VM with Oracle VirtualBox 5.x versions.

The VM is able to boot but Vagrant cannot reach it, the ssh client is unable to connect to the VM because the NAT interface is not marked as "Cable connected".

References:
* https://github.com/hashicorp/vagrant/issues/7648
* https://github.com/laravel/homestead/issues/383