### PR TITLE
Introduce workaround for dnsmasq systemd service overwriting /etc/resolv.conf

### DIFF
--- a/provision/ansible/roles/dnsmasq/tasks/install.yml
+++ b/provision/ansible/roles/dnsmasq/tasks/install.yml
@@ -1,5 +1,24 @@
 ---
 
+# Prevent dnsmasq service from overwriting resolv.conf
+# so that host DNS settings are retained (for Docker usage)
+# https://github.com/bsdcon/vagrant-docker-vm/issues/8
+# Note: must be done early, before dnsmasq service is installed+started
+- name: Prepare dnsmasq.service.d placeholder
+  file:
+    path:    /etc/systemd/system/dnsmasq.service.d
+    state:   directory
+    recurse: yes
+    mode:    0755
+
+- name: Prepare systemd override for dnsmasq
+  copy:
+    src:   templates/workaround-resolv.conf
+    dest:  /etc/systemd/system/dnsmasq.service.d/workaround-resolv.conf
+    owner: vagrant
+    group: root
+    mode:  0644
+
 - name: Install dnsmasq
   apt:
     pkg:   '{{ item }}'

--- a/provision/ansible/roles/dnsmasq/templates/workaround-resolv.conf
+++ b/provision/ansible/roles/dnsmasq/templates/workaround-resolv.conf
@@ -1,0 +1,10 @@
+# Override dnsmasq service configuration to prevent calling the
+# systemd-*-resolvconf functions from /etc/init.d/dnsmasq (which overwrites 
+# /etc/resolv.conf) so that host DNS settings are retained (for Docker usage)
+#
+# https://github.com/bsdcon/vagrant-docker-vm/issues/8
+#
+# Note: the injection of 127.0.0.1 nameserver in resolv.conf is left for Dory service
+[Service]
+ExecStartPost=
+ExecStop=


### PR DESCRIPTION
This prevents Docker service from properly auto-configuring DNS settings
for cotainers.
Note: we will rely on Dory to inject the 127.0.0.1 nameserver

This fixes #8