### PR TITLE
Bugfix/docker service restart refactoring

### DIFF
--- a/provision/ansible/roles/docker/handlers/main.yml
+++ b/provision/ansible/roles/docker/handlers/main.yml
@@ -4,8 +4,4 @@
   command: 'service apparmor reload'
 
 - name: Restart Docker
-  command: '{{ item }}'
-  with_items:
-    - systemctl daemon-reload
-    - systemctl enable docker
-    - systemctl restart docker
+  command: 'service docker restart'

--- a/provision/ansible/roles/docker/tasks/configuration.yml
+++ b/provision/ansible/roles/docker/tasks/configuration.yml
@@ -14,8 +14,7 @@
     owner: vagrant
     group: root
     mode:  0644
-  notify:
-    - Restart Docker
+  register: docker_cust_opts
 
 # Since Docker is installed *after* the VM is created, the vagrant-proxyconf plugin
 # won't apply any proxy configuration for Docker on first startup...
@@ -26,12 +25,14 @@
     owner: vagrant
     group: root
     mode:  0644
-  notify:
-    - Restart Docker
+  register: docker_proxy_workaround
 
-# Systemd needs to load the above applied changes
+# Systemd needs to reload (and service restarted) when changes are applied above
 - name: Reload systemd configuration
   command: 'systemctl daemon-reload'
+  when: docker_cust_opts.changed or docker_proxy_workaround.changed
+  notify:
+    - Restart Docker
 
 #############################
 # Apparmor profile

--- a/provision/ansible/roles/docker/tasks/configuration.yml
+++ b/provision/ansible/roles/docker/tasks/configuration.yml
@@ -34,6 +34,10 @@
   notify:
     - Restart Docker
 
+# Complete any pending Docker service restarts to be prepared for next actions
+# where we may need it running with correct configuration (e.g. proxy settings)
+- meta: flush_handlers
+
 #############################
 # Apparmor profile
 #############################

--- a/provision/ansible/roles/docker/tasks/configuration.yml
+++ b/provision/ansible/roles/docker/tasks/configuration.yml
@@ -29,6 +29,10 @@
   notify:
     - Restart Docker
 
+# Systemd needs to load the above applied changes
+- name: Reload systemd configuration
+  command: 'systemctl daemon-reload'
+
 #############################
 # Apparmor profile
 #############################

--- a/provision/ansible/roles/docker/tasks/install.yml
+++ b/provision/ansible/roles/docker/tasks/install.yml
@@ -43,6 +43,9 @@
   with_items:
     - docker-ce
 
+- name: Enable Docker service
+  command: 'systemctl enable docker'
+
 - name: Install Docker Compose
   pip:
     name: docker-compose

--- a/provision/ansible/roles/docker/tasks/main.yml
+++ b/provision/ansible/roles/docker/tasks/main.yml
@@ -8,10 +8,6 @@
   tags:
     - bootstrap
 
-# Need to immediately restart Docker services to properly handle the next
-# actions where we may need it running with correct configuration
-- meta: flush_handlers
-
 - include: maintenance.yml
   tags:
     - bootstrap

--- a/provision/ansible/roles/firewall/handlers/main.yml
+++ b/provision/ansible/roles/firewall/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
 
-- name: Restart Docker
-  command: 'service docker restart'
+# already defined in 'docker' role
+#- name: Restart Docker
+#  command: 'service docker restart'

--- a/provision/ansible/roles/firewall/tasks/configuration.yml
+++ b/provision/ansible/roles/firewall/tasks/configuration.yml
@@ -12,3 +12,8 @@
 
 - name: Start firewall
   command: 'service firewall-vm restart'
+
+# Since this impacts Docker, we need to complete any pending restarts, before
+# attempting to bring up any containers, otherwise running the handler late
+# will bring down any containers that we (re)create
+- meta: flush_handlers


### PR DESCRIPTION
Refactored the code around Docker service restart in order to make it function correctly.
Code built on top of existing branch _feature/enable-proxy-usage_ since it affects code already refactored there. For this reason it will likely be integrated back into that branch.

Fixes https://github.com/bsdcon/vagrant-docker-vm/issues/7